### PR TITLE
Add styling to the results list component Typography

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,13 +1,11 @@
 import React, { useContext } from 'react';
-import { Typography, ThemeProvider } from '@mui/material'
+import { ThemeProvider } from '@mui/material'
 import { myTheme } from './theme/myTheme';
-import { useTranslation } from 'react-i18next';
 import './config/i18n/i18n';
 import { BusinessResultsList } from './components/BusinessResultsList/businessResultsList';
 import { SearchContext } from './context/SearchContext';
 
 function Search() {
-    const { t } = useTranslation();
     const { term, city } = useContext(SearchContext)
 
 
@@ -19,9 +17,6 @@ function Search() {
     
     return (
         <ThemeProvider theme={myTheme}>
-            <Typography>
-                {`You're looking for ${term} in ${city}`}
-            </Typography>
             <BusinessResultsList />
         </ThemeProvider>
     );

--- a/src/components/BusinessResultsList/businessResultsList.tsx
+++ b/src/components/BusinessResultsList/businessResultsList.tsx
@@ -1,5 +1,6 @@
 import React, { FC, ReactElement, useContext } from 'react';
-import { Box, List, ListItem, Divider } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { Box, List, ListItem, Divider, Typography } from '@mui/material';
 import { gql , useQuery } from '@apollo/client';
 import { Business } from '../../generated/graphql';
 import { BusinessMainDetailsCard } from '../../components/BusinessMainDetailsCard/businessMainDetailsCard';
@@ -36,13 +37,18 @@ interface IBusinessResultsList {
 
 
 export const BusinessResultsList: FC = (): ReactElement => {
+    const { t } = useTranslation();
     const { term, city } = useContext(SearchContext)
 
-
+    const capitalize = (str: string) => {
+        return str.charAt(0).toUpperCase() + str.slice(1);
+    };
+    
     const styles = {
         businessListBox: {
             width: '100%',
-            marginLeft: 2
+            marginLeft: 4,
+            marginTop: 4
         },
         businessListItemBox: { 
             width: '100%',
@@ -52,6 +58,12 @@ export const BusinessResultsList: FC = (): ReactElement => {
             marginTop: 2,
             marginBottom: 2
           },
+        resultsListTitle: {
+            fontWeight: 700,
+            fontSize: 25,
+            fontFamily: "Helvetica Neue",
+            marginBottom: 1
+        },
     }
 
     // run query
@@ -68,21 +80,26 @@ export const BusinessResultsList: FC = (): ReactElement => {
     if (error) return <div>error</div>;
 
     return(
-        <List sx={styles.businessListBox}>
-              
-            {data?.searchBusinesses?.map((business: Business) => (
-                <>
-                    <ListItem alignItems="flex-start" key={business.id}>
-                        <Box sx={styles.businessListItemBox}>
-                            <BusinessMainDetailsCard businessData={business}/>
-                        </Box>
-                    </ListItem>
-                    <Box sx={styles.dividerBox}>
-                        <Divider variant="middle" component="li" />
-                    </Box>
-                </>
-            ))}
+        <Box sx={styles.businessListBox}>
+            <Typography sx={styles.resultsListTitle}>
+                {`${t("businessResultsList.title.looking")} "${capitalize(term)}" ${t("businessResultsList.title.in")} ${capitalize(city)}`}
+            </Typography>
 
-        </List>
+            <List>
+                
+                {data?.searchBusinesses?.map((business: Business) => (
+                    <>
+                        <ListItem alignItems="flex-start" key={business.id}>
+                            <Box sx={styles.businessListItemBox}>
+                                <BusinessMainDetailsCard businessData={business}/>
+                            </Box>
+                        </ListItem>
+                        <Box sx={styles.dividerBox}>
+                            <Divider variant="middle" component="li" />
+                        </Box>
+                    </>
+                ))}
+            </List>
+        </Box>
     )
 }

--- a/src/config/i18n/locale/en.json
+++ b/src/config/i18n/locale/en.json
@@ -11,5 +11,8 @@
     "businessesGrid.title": "Some lovely places in Barcelona",
 
     "businessDetail.open": "Open",
-    "businessDetail.closed": "Closed"
+    "businessDetail.closed": "Closed",
+
+    "businessResultsList.title.looking": "You're looking for",
+    "businessResultsList.title.in": "in"
 }

--- a/src/config/i18n/locale/es.json
+++ b/src/config/i18n/locale/es.json
@@ -11,5 +11,8 @@
     "businessesGrid.title": "Algunos lugares encantadores en Barcelona",
 
     "businessDetail.open": "Abierto",
-    "businessDetail.closed": "Cerrado"
+    "businessDetail.closed": "Cerrado",
+
+    "businessResultsList.title.looking": "Estás buscando",
+    "businessResultsList.title.in": "en"
 }


### PR DESCRIPTION
- The user makes a search and the title above the results displays the term and city entered by the user.
- Adding missing translations

**Screenshot**
In this case, the user entered `pizza` and `rome` at the `/` path:

![image](https://github.com/falessa/restaurants-catalog/assets/19618215/878a6027-2196-450b-8b97-fba91d5fe9a3)
