### PR TITLE
Show SearchInput in Header when not at / path

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,20 +1,9 @@
-import React, { useContext } from 'react';
-import { ThemeProvider } from '@mui/material'
+import React from 'react';
+import { ThemeProvider } from '@mui/material';
 import { myTheme } from './theme/myTheme';
-import './config/i18n/i18n';
 import { BusinessResultsList } from './components/BusinessResultsList/businessResultsList';
-import { SearchContext } from './context/SearchContext';
 
 function Search() {
-    const { term, city } = useContext(SearchContext)
-
-
-    const styles = {
-        businessDetailsCard: {
-
-        }
-    }
-    
     return (
         <ThemeProvider theme={myTheme}>
             <BusinessResultsList />

--- a/src/components/BusinessMainDetailsCard/businessMainDetailsCard.tsx
+++ b/src/components/BusinessMainDetailsCard/businessMainDetailsCard.tsx
@@ -30,7 +30,6 @@ export const BusinessMainDetailsCard: FC<IBusinessMainDetailsCard> = (props): Re
             fontWeight: 700,
             fontSize: 20,
             fontFamily: "Helvetica Neue",
-            // marginBottom: "0px"
         },
         businessMainDetailsIsOpen: {
             fontWeight: 700,
@@ -98,7 +97,7 @@ export const BusinessMainDetailsCard: FC<IBusinessMainDetailsCard> = (props): Re
                 <Box sx={styles.businessMainDetailsPriceAddressBox}>
                     <Chip size="small" label="$$"/>
                     <Typography sx={styles.businessMainDetailsAddressText}>
-                        {businessData?.location?.address1 + ` ` + businessData?.location?.postal_code}
+                        {businessData?.location?.address1 + `, ` + businessData?.location?.postal_code}
                     </Typography>
                 </Box>
 

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -3,10 +3,14 @@ import yelpLogo from '../../resources/images/yelp_logo.png';
 import { Box } from '@mui/material';
 import { Image } from 'mui-image';
 import { LanguageSelector } from '../LanguageSelector/languageSelector';
-import { useNavigate } from 'react-router-dom';
+import { SearchInput } from '../SearchInput/searchInput';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 export const Header: FC = (): ReactElement => {
     const navigate = useNavigate();
+    const location = useLocation();
+
+    const shouldDisplaySearchInput = location.pathname !== '/';
     
     const styles = {
         headerBox: {
@@ -34,6 +38,11 @@ export const Header: FC = (): ReactElement => {
                 alt='restaurant-catalog-logo'
                 />
             </Box>
+            {shouldDisplaySearchInput &&
+                <Box>
+                    <SearchInput />
+                </Box>
+            }
             <Box>
                 <LanguageSelector />
             </Box>

--- a/src/components/SearchInput/searchInput.tsx
+++ b/src/components/SearchInput/searchInput.tsx
@@ -29,11 +29,6 @@ export const SearchInput: FC<ISearchInput> = (props): ReactElement => {
      } = props;
 
     const styles = {
-        searchBox: {
-            display: 'flex',
-            justifyContent: 'center',
-
-        },
         searchIconButton: {
             backgroundColor: "red",
             borderRadius: "1px",
@@ -45,15 +40,27 @@ export const SearchInput: FC<ISearchInput> = (props): ReactElement => {
         }
     }
 
+    // Update term and city with values from SearchContext if available
+    useEffect(() => {
+        if (searchContext.term) {
+        setTerm(searchContext.term);
+        }
+        if (searchContext.city) {
+        setCity(searchContext.city);
+        }
+    }, [searchContext.term, searchContext.city]);
+
     return(
-        <Box sx={styles.searchBox}>
-            <TextInputCustom
+        <Box>
+            <TextInputCustom data-test="search-term"
                 onChange={(e) => setTerm(e.target.value)}
                 placeholder={t("searchInput.searchTerm") || ""}
+                value={term}
             />
-            <TextInputCustom
+            <TextInputCustom data-test="search-city"
                 onChange={(e) => setCity(e.target.value)}
                 placeholder={t("searchInput.city") || ""}
+                value={city}
             />
             <IconButton sx={styles.searchIconButton} size="large" onClick={() => handleClick()}>
                 <Search sx={styles.icon} />

--- a/src/components/TextInputCustom/textInputCustom.tsx
+++ b/src/components/TextInputCustom/textInputCustom.tsx
@@ -12,14 +12,16 @@ const styles = {
   };
 
 interface ITextInputCustom {
-    placeholder?: string
+    placeholder?: string;
+    value?: string;
     onChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement> ) => void;
 }
   
 export const TextInputCustom: FC<ITextInputCustom> = (props): ReactElement => {
     const {
         placeholder = "some placeholder",
-        onChange = () => {}
+        onChange = () => {},
+        value=""
     } = props;
 
     return(
@@ -27,6 +29,7 @@ export const TextInputCustom: FC<ITextInputCustom> = (props): ReactElement => {
             InputProps={{ sx: styles.common}}
             placeholder={placeholder}
             onChange={onChange}
+            value={value}
         />
     )
 }


### PR DESCRIPTION
1- Show SearchInput component in Header **when not at** `/` path, and displayed the search values at the text inputs

![image](https://github.com/falessa/restaurants-catalog/assets/19618215/675d4674-b7fd-45d2-99ff-bd338aba8d58)

2- Does not show SearchInput component in Header at `/` path:

![image](https://github.com/falessa/restaurants-catalog/assets/19618215/5c44cd3d-76a5-4caa-8388-7c6cb2d7c774)
